### PR TITLE
Add some useful functions

### DIFF
--- a/tess-two/jni/com_googlecode_tesseract_android/pageiterator.cpp
+++ b/tess-two/jni/com_googlecode_tesseract_android/pageiterator.cpp
@@ -41,6 +41,29 @@ jboolean Java_com_googlecode_tesseract_android_PageIterator_nativeNext(JNIEnv *e
   return pageIterator->Next(enumLevel) ? JNI_TRUE : JNI_FALSE;
 }
 
+jintArray Java_com_googlecode_tesseract_android_PageIterator_nativeBoundingBox(JNIEnv *env, jclass clazz,
+    jint nativePageIterator, jint level) {
+  int size = 4;
+  jintArray result = env->NewIntArray(size);
+
+  LOG_ASSERT((result != NULL), "Could not create Java confidence array!");
+  
+  PageIterator *pageIterator = (PageIterator *) nativePageIterator;
+  PageIteratorLevel enumLevel = (PageIteratorLevel) level;
+  int x1, y1, x2, y2;
+  pageIterator->BoundingBox(enumLevel, &x1, &y1, &x2, &y2);
+  
+  // fill a temp structure to use to populate the java int array
+  jint fill[6];
+  fill[0] = x1;
+  fill[1] = y1;
+  fill[2] = x2;
+  fill[3] = y2;
+ 
+  env->SetIntArrayRegion(result, 0, size, fill);
+ return result;
+}
+
 #ifdef __cplusplus
 }
 #endif  /* __cplusplus */

--- a/tess-two/jni/com_googlecode_tesseract_android/tessbaseapi.cpp
+++ b/tess-two/jni/com_googlecode_tesseract_android/tessbaseapi.cpp
@@ -422,6 +422,60 @@ jint Java_com_googlecode_tesseract_android_TessBaseAPI_nativeGetResultIterator(J
   return (jint) nat->api.GetIterator();
 }
 
+jstring Java_com_googlecode_tesseract_android_TessBaseAPI_nativeGetHOCRText(JNIEnv *env,
+                                                                            jobject thiz, jint page) {
+
+  native_data_t *nat = get_native_data(env, thiz);
+
+  char *text = nat->api.GetHOCRText(page);
+
+  jstring result = env->NewStringUTF(text);
+
+  free(text);
+
+  return result;
+}
+
+jstring Java_com_googlecode_tesseract_android_TessBaseAPI_nativeGetBoxText(JNIEnv *env,
+                                                                            jobject thiz, jint page) {
+
+  native_data_t *nat = get_native_data(env, thiz);
+
+  char *text = nat->api.GetBoxText(page);
+
+  jstring result = env->NewStringUTF(text);
+
+  free(text);
+
+  return result;
+}
+
+void Java_com_googlecode_tesseract_android_TessBaseAPI_nativeSetInputName(JNIEnv *env,
+                                                                             jobject thiz,
+                                                                             jstring name) {  
+  native_data_t *nat = get_native_data(env, thiz);
+  const char *c_name = env->GetStringUTFChars(name, NULL);
+  nat->api.SetInputName(c_name);
+  env->ReleaseStringUTFChars(name, c_name);
+} 
+
+void Java_com_googlecode_tesseract_android_TessBaseAPI_nativeSetOutputName(JNIEnv *env,
+                                                                             jobject thiz,
+                                                                             jstring name) {
+  native_data_t *nat = get_native_data(env, thiz);
+  const char *c_name = env->GetStringUTFChars(name, NULL);
+  nat->api.SetOutputName(c_name);
+  env->ReleaseStringUTFChars(name, c_name);
+} 
+
+void Java_com_googlecode_tesseract_android_TessBaseAPI_nativeReadConfigFile(JNIEnv *env,
+                                                                             jobject thiz,
+                                                                             jstring fileName) {
+  native_data_t *nat = get_native_data(env, thiz);
+  const char *c_file_name = env->GetStringUTFChars(fileName, NULL);
+  nat->api.ReadConfigFile(c_file_name);
+  env->ReleaseStringUTFChars(fileName, c_file_name);
+} 
 #ifdef __cplusplus
 }
 #endif

--- a/tess-two/src/com/googlecode/tesseract/android/PageIterator.java
+++ b/tess-two/src/com/googlecode/tesseract/android/PageIterator.java
@@ -60,6 +60,16 @@ public class PageIterator {
         return nativeNext(mNativePageIterator, level);
     }
 
+    /**
+     * get bounding box x,y,w,h
+     * @param level
+     * @return
+     */
+    public int[] getBoundingBox(int level){
+    	return nativeBoundingBox(mNativePageIterator, level);
+    }
+    
     private static native void nativeBegin(int nativeIterator);
     private static native boolean nativeNext(int nativeIterator, int level);
+    private static native int[] nativeBoundingBox(int nativeIterator, int level);
 }

--- a/tess-two/src/com/googlecode/tesseract/android/TessBaseAPI.java
+++ b/tess-two/src/com/googlecode/tesseract/android/TessBaseAPI.java
@@ -486,6 +486,56 @@ public class TessBaseAPI {
         return new ResultIterator(nativeResultIterator);
     }
     
+	/**
+	 * 
+	 * Make a HTML-formatted string with hOCR markup from the internal data
+	 * structures.  
+	 * GetHOCRText STL removed from original patch submission and refactored by
+	 * rays.
+	 * <b>Warning</b> make sure call {@link #setInputName} before this method
+	 * @param page is 0-based but will appear in the output as 1-based. 
+	 * @return HTML-formatted string with hOCR markup
+	 */
+    public String getHOCRText(int page){
+    	return nativeGetHOCRText(page);
+    }
+    
+    /**
+     * Set the name of the input file. Needed only for training and
+     * loading a UNLV zone file.
+     *  @param name input file name
+     */
+    public void setInputName(String name){
+    	nativeSetInputName(name);
+    } 
+    
+    /** Set the name of the output files. 
+     * Needed only for debugging. 
+     * @param name output file name
+     */
+    public void setOutputName(String name){
+    	nativeSetOutputName(name);
+    } 
+    
+    /**
+     * Read a "config" file containing a set of parameter name, value pairs.
+     * Searches the standard places: <i>tessdata/configs, tessdata/tessconfigs</i>
+     * and also accepts a relative or absolute path name.
+     * @param filename the configuration file name, without path, should be place in <b>tessdata/configs, tessdata/tessconfigs</b>
+     */
+    public void ReadConfigFile(String filename){
+    	nativeReadConfigFile(filename);
+    }
+    
+    /**
+     * The recognized text is returned which is coded
+     * as a UTF8 box file.
+     * @param page is a 0-base page index that will appear in the box file.
+     */
+    public String getBoxText(int page){
+    	return nativeGetBoxText(page);
+    }
+
     // ******************
     // * Native methods *
     // ******************
@@ -543,4 +593,14 @@ public class TessBaseAPI {
     private native int nativeGetWords();
 
     private native int nativeGetResultIterator();
+    
+    private native String nativeGetBoxText(int page_number);
+    
+    private native String nativeGetHOCRText(int page_number);
+    
+    private native void nativeSetInputName(String name);
+    
+    private native void nativeSetOutputName(String name);
+    
+    private native void nativeReadConfigFile(String fileName);
 }


### PR DESCRIPTION
There are 5 extend functions in base api: `GetBoxText`, `GetHOCRText`, `SetInputName`, `SetOutputName`, `ReadConfigFile`

Here is the example for new apis:

``` Java
     TessBaseAPI baseApi = new TessBaseAPI();
     // use the most accuracy mode.
     baseApi.init(appPath, "eng", TessBaseAPI.OEM_TESSERACT_CUBE_COMBINED);

     // set config output hocr
     baseApi.setVariable("tessedit_create_hocr", "1");
     baseApi.setImage(new File(grayScaleFileName));

     // set the filename for hocr output
     baseApi.setInputName("hocr.html");

     String hocr = baseApi.getHOCRText(0);
     String recognizedText = baseApi.getUTF8Text();
     String boxText = baseApi.getBoxText(0);
```

This is the input ocr image:
![20140213_145057_675_grayscale](https://f.cloud.github.com/assets/2063905/2157773/66b1b926-9484-11e3-933b-93e69049d6aa.jpg)

And the results:
- [Raw text](http://pastebin.com/kBAarJpG)
- [Hocr output](http://pastebin.com/1bGimDhz)
- [Box text](http://pastebin.com/MR6jY6GS)

For the `Page Iterator`, I created test case base on [tesseract 's document](https://code.google.com/p/tesseract-ocr/wiki/APIExample#Result_iterator_example)

``` Java
     ResultIterator iterator = baseApi.getResultIterator();
        int level = PageIteratorLevel.RIL_WORD;
        if(iterator != null){       
        do{
            String dataText = iterator.getUTF8Text(level);
            float confident = iterator.confidence(level);
            if(!TextUtils.isEmpty(dataText)){
                int[] box = iterator.getBoundingBox(level);
                System.out.println(box);
            }       
        }while(iterator.next(level));
            iterator = null;
        } 
```
