### PR TITLE
Fix memory leak in setImage(Bitmap bmp)

### DIFF
--- a/tess-two/src/com/googlecode/tesseract/android/TessBaseAPI.java
+++ b/tess-two/src/com/googlecode/tesseract/android/TessBaseAPI.java
@@ -514,6 +514,8 @@ public class TessBaseAPI {
         }
 
         nativeSetImagePix(image.getNativePix());
+        
+        image.recycle();
     }
 
     /**


### PR DESCRIPTION
Hello, this is my first pull request to an open source project, so please excuse me if I've done anything wrong and I'll fix my mistakes.

I am working on a project, which rapidly uses OCR provided by tess-two, and noticed a memory leak. I narrowed it down and found that, instead of calling setImage(Bitmap), I could create a Pix object myself, call setImage(Pix), and then recycle the Pix object. This fixed the memory leak for me, but I believe this commit will fix the memory leak when using the Bitmap variant of the method. There is no way to recycle the Pix object outside of this call, since it is only used as a temporary local object.

I tested this and it does seem to work, but I am no expert on Tesseract, so please let me know if you see any issues that may arise.

Thanks for your time.