### PR TITLE
clone tag 3.04.00 from tessdata

### DIFF
--- a/preparetests.cmd
+++ b/preparetests.cmd
@@ -1,6 +1,6 @@
 for /f %%i in ('adb shell echo $EXTERNAL_STORAGE') do set DIR=%%i
 
-git clone https://github.com/tesseract-ocr/tessdata.git
+git clone -b 3.04.00 https://github.com/tesseract-ocr/tessdata.git
 
 adb shell rm %DIR%/testAddPageToDocument.pdf
 adb shell rm %DIR%/testCreate.pdf

--- a/preparetests.sh
+++ b/preparetests.sh
@@ -2,7 +2,7 @@
 
 DIR="`adb shell echo \\$EXTERNAL_STORAGE`"
 
-git clone https://github.com/tesseract-ocr/tessdata.git
+git clone -b 3.04.00 https://github.com/tesseract-ocr/tessdata.git
 
 adb shell rm $DIR/testAddPageToDocument.pdf
 adb shell rm $DIR/testCreate.pdf


### PR DESCRIPTION
make the shell scripts clone from branch/tag 3.04.00, as this is where the eng.cube.* files are located.
apparently the master branch of tessdata contains traineddata for tesseract 4