### PR TITLE
Fix https://github.com/rmtheis/tess-two/issues/159

### DIFF
--- a/tess-two-test/src/com/googlecode/leptonica/android/test/PixaTest.java
+++ b/tess-two-test/src/com/googlecode/leptonica/android/test/PixaTest.java
@@ -146,38 +146,36 @@ public class PixaTest extends TestCase {
         pixaB.recycle();
     }
 
-//    @SmallTest
-//    public void testPixaReplacePix() {
-//        Pixa pixa = Pixa.createPixa(0, 640, 480);
-//
-//        // Populate the Pixa.
-//        addBlockToPixa(pixa, 0, 0, 640, 480, 8);
-//
-//        Pix pix = new Pix(320, 240, 8);
-//        Box box = new Box(320, 240, 320, 240);
-//
-//        // Replace the existing Pix.
-//        pixa.replacePix(0, pix, box);
-//
-//        // Ensure the replacement was successful.
-//        Pix returnedPix = pixa.getPix(0);
-//        Box returnedBox = pixa.getBox(0);
-//
-//        assertEquals(pix.getWidth(), returnedPix.getWidth());
-//        assertEquals(pix.getHeight(), returnedPix.getHeight());
-//        assertEquals(pix.getDepth(), returnedPix.getDepth());
-//
-//        assertEquals(box.getX(), returnedBox.getX());
-//        assertEquals(box.getY(), returnedBox.getY());
-//        assertEquals(box.getWidth(), returnedBox.getWidth());
-//        assertEquals(box.getHeight(), returnedBox.getHeight());
-//
-//        pix.recycle();
-//        box.recycle();
-//        returnedPix.recycle();
-//        returnedBox.recycle();
-//        pixa.recycle();
-//    }
+    @SmallTest
+    public void testPixaReplacePix() {
+        Pixa pixa = Pixa.createPixa(0, 640, 480);
+
+        // Populate the Pixa.
+        addBlockToPixa(pixa, 0, 0, 640, 480, 8);
+
+        Pix pix = new Pix(320, 240, 8);
+        Box box = new Box(320, 240, 320, 240);
+
+        // Replace the existing Pix.
+        pixa.replacePix(0, pix, box);
+
+        // Ensure the replacement was successful.
+        Pix returnedPix = pixa.getPix(0);
+        Box returnedBox = pixa.getBox(0);
+
+        assertEquals(pix.getWidth(), returnedPix.getWidth());
+        assertEquals(pix.getHeight(), returnedPix.getHeight());
+        assertEquals(pix.getDepth(), returnedPix.getDepth());
+
+        assertEquals(box.getX(), returnedBox.getX());
+        assertEquals(box.getY(), returnedBox.getY());
+        assertEquals(box.getWidth(), returnedBox.getWidth());
+        assertEquals(box.getHeight(), returnedBox.getHeight());
+
+        returnedPix.recycle();
+        returnedBox.recycle();
+        pixa.recycle();
+    }
 
     @SmallTest
     public void testPixaMergeAndReplacePix() {

--- a/tess-two/src/com/googlecode/leptonica/android/Pixa.java
+++ b/tess-two/src/com/googlecode/leptonica/android/Pixa.java
@@ -412,11 +412,11 @@ public class Pixa implements Iterable<Pix> {
 
     /**
      * Replaces the Pix and Box at the specified index with the specified Pix
-     * and Box, both of which may be recycled after calling this method.
+     * and Box, both of which should not be recycled after calling this method.
      *
      * @param index The index of the Pix to replace.
-     * @param pix The Pix to replace the existing Pix.
-     * @param box The Box to replace the existing Box.
+     * @param pix The Pix to replace the existing Pix; it becomes an alias of the one stored in Pixa.
+     * @param box The Box to replace the existing Box; it becomes an alias of the one stored in Pixa.
      */
     public void replacePix(int index, Pix pix, Box box) {
         if (mRecycled)


### PR DESCRIPTION
As a result of discussion with @DanBloomberg, the test that was commented out, can now be re-enabled.
The change for `Pixa.replacePix()` method only concerns the JavaDoc, but is very important. I would suggest to rewrite the test such:

    public void testPixaReplacePix() {
        Pixa pixa = Pixa.createPixa(0, 640, 480);

        // Populate the Pixa.
        addBlockToPixa(pixa, 0, 0, 640, 480, 8);

        // Replace the existing Pix.
        pixa.replacePix(0, new Pix(320, 240, 8), new Box(320, 240, 320, 240));

        // Ensure the replacement was successful.
        Pix returnedPix = pixa.getPix(0);
        Box returnedBox = pixa.getBox(0);

        assertEquals(320, returnedPix.getWidth());
        assertEquals(240, returnedPix.getHeight());
        assertEquals(8, returnedPix.getDepth());

        assertEquals(320, returnedBox.getX());
        assertEquals(240, returnedBox.getY());
        assertEquals(320, returnedBox.getWidth());
        assertEquals(240, returnedBox.getHeight());

        returnedPix.recycle();
        returnedBox.recycle();
        pixa.recycle();
    }

This should emphasize that the parameters of `replacePix` method actually become zombies, and should not be recycled or referenced anymore.